### PR TITLE
method name fix s/thumnail/thumbnail

### DIFF
--- a/notebooks/clustering.ipynb
+++ b/notebooks/clustering.ipynb
@@ -124,7 +124,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "thumbnail_ticket_id = ce_api_client.thumnail_repos(ids=repo_ids)\n",
+    "thumbnail_ticket_id = ce_api_client.thumbnail_repos(ids=repo_ids)\n",
     "print(thumbnail_ticket_id)"
    ]
   },

--- a/notebooks/regions-of-interest.ipynb
+++ b/notebooks/regions-of-interest.ipynb
@@ -55,7 +55,7 @@
    "source": [
     "image_id = 6453\n",
     "image_ids = [image_id] # A sinlge image from the IMPRESS Dataset\n",
-    "ticket_id = ce_api_client.thumnail_images(ids=image_ids)\n",
+    "ticket_id = ce_api_client.thumbnail_images(ids=image_ids)\n",
     "print(ticket_id)"
    ]
   },

--- a/notebooks/segmentation.ipynb
+++ b/notebooks/segmentation.ipynb
@@ -458,7 +458,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "thumbnail_ticket_id = ce_api_client.thumnail_repos(ids=repository_ids)\n",
+                "thumbnail_ticket_id = ce_api_client.thumbnail_repos(ids=repository_ids)\n",
                 "print(thumbnail_ticket_id)"
             ]
         },

--- a/utils/client.py
+++ b/utils/client.py
@@ -90,7 +90,7 @@ class ClientWrapper:
         data = {"input_type": "image_ids", "input": ids, "mpp": mpp, "model": model}
         return self._submit_job(data)
 
-    def thumnail_images(self, ids: List[int]) -> str:
+    def thumbnail_images(self, ids: List[int]) -> str:
         """
         Submits a job to produce thumbnails of a list of images.
 
@@ -105,7 +105,7 @@ class ClientWrapper:
         data = {"input_type": "image_ids", "input": ids}
         return self._submit_job(data, thumbnails=True)
 
-    def thumnail_repos(self, ids: List[int]) -> str:
+    def thumbnail_repos(self, ids: List[int]) -> str:
         """
         Submits a job to produce thumbnails of a list of repository ids.
 


### PR DESCRIPTION
## What/Why?

Fix a typo in the name of a client method.