### PR TITLE
Handle failed cases within loader

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -200,6 +200,12 @@ def test_poll_for_completion_and_fetch_results(mock_fetch_results, mock_get_job_
         path = client_wrapper.download_embedding("https://fakeurl.com/embedding")
         assert os.path.exists(path)
 
+    @patch("requests.get")
+    def test_download_failed_embedding(mock_get, client_wrapper):
+        mock_get.return_value.content = None
+        path = client_wrapper.download_embedding(None)
+        assert path is None
+
     @patch("safetensors.safe_open")
     def test_load_embedding(mock_safe_open, client_wrapper):
         mock_safe_open.return_value.__enter__.return_value.keys.return_value = ["key1"]
@@ -212,6 +218,12 @@ def test_poll_for_completion_and_fetch_results(mock_fetch_results, mock_get_job_
         mock_get.return_value.content = b"fake_content"
         path = client_wrapper.download_thumbnail("https://fakeurl.com/thumbnail")
         assert os.path.exists(path)
+
+    @patch("requests.get")
+    def test_download_failed_thumbnail(mock_get, client_wrapper):
+        mock_get.return_value.content = None
+        path = client_wrapper.download_thumbnail(None)
+        assert path is None
 
     @patch("imageio.v2.imread")
     def test_load_thumbnail(mock_imread, client_wrapper):

--- a/utils/client.py
+++ b/utils/client.py
@@ -236,7 +236,7 @@ class ClientWrapper:
             for image in images:
                 local_embedding_path = image.get("local_embedding_path", None)
                 if download_embeddings:
-                    local_embedding_path = self.download_embedding(image["embeddings_url"])
+                    local_embedding_path = self.download_embedding(image.get("embeddings_url", None))
                 if load_embeddings and local_embedding_path is not None:
                     embedding = self.load_embedding(local_embedding_path)
                     image.update({"embedding": embedding})
@@ -267,6 +267,8 @@ class ClientWrapper:
         -------
         dict: The embeddings.
         """
+        if embeddings_url is None:
+            return None
         fname = os.path.basename(embeddings_url).split("?")[0]
         path = os.path.join(self.cache_dir, fname)
         if not os.path.exists(path):
@@ -309,6 +311,8 @@ class ClientWrapper:
         -------
         str: The path to the thumbnail image.
         """
+        if thumbnail_url is None:
+            return None
         fname = os.path.basename(thumbnail_url).split("?")[0]
         local_path = os.path.join(self.cache_dir, fname)
         if not os.path.exists(local_path):
@@ -421,7 +425,7 @@ class ClientWrapper:
             for image in images:
                 local_thumbnail_path = image.get("local_thumbnail_path", None)
                 if download_thumbnails:
-                    local_thumbnail_path = self.download_thumbnail(image["thumb_url"])
+                    local_thumbnail_path = self.download_thumbnail(image.get("thumb_url", None))
                 if load_thumbnails and local_thumbnail_path is not None:
                     thumbnail = self.load_thumbnail(local_thumbnail_path)
                     image.update({"thumbnail": thumbnail})


### PR DESCRIPTION
## What/Why?

When individual slides fail when producing embeddings or thumbnails, we still want to load the successful slides. This change lets failed slides skip the loading step during `client.get_embeddings`

## Reviewers

@Proscia/ai-scientists