### PR TITLE
Add check/create module to create_overlay

### DIFF
--- a/tests/test_concentriqlsclient.py
+++ b/tests/test_concentriqlsclient.py
@@ -28,10 +28,25 @@ def ls_client():
 
 @patch("requests.Session.post")
 def test_create_overlay(mock_post, ls_client):
+    ls_client.module_exists = MagicMock(return_value=True)
+    ls_client.update_module = MagicMock(return_value={"id": 1})
+    mock_post.return_value = mock_response(json_data='{"data": {"id": 1, "name": "overlay"}}')
+    ls_client.module_id = 1
+    response = ls_client.create_overlay(image_id=1, overlay_name="overlay")
+    assert response["id"] == 1
+    assert response["name"] == "overlay"
+
+
+@patch("requests.Session.post")
+def test_create_overlay_no_module(mock_post, ls_client):
+    ls_client.module_exists = MagicMock(return_value=False)
+    ls_client.update_module = MagicMock(return_value={"id": 1})
+    ls_client.create_module = MagicMock(return_value={"id": 1})
     mock_post.return_value = mock_response(json_data='{"data": {"id": 1, "name": "overlay"}}')
     response = ls_client.create_overlay(image_id=1, overlay_name="overlay")
     assert response["id"] == 1
     assert response["name"] == "overlay"
+    assert ls_client.create_module.called
 
 
 @patch("requests.Session.get")
@@ -49,6 +64,8 @@ def test_sign_overlay_s3_url(mock_get, ls_client):
 def test_insert_heatmap_overlay(mock_put, mock_get, mock_post, mock_image_as_bytes, mock_create_overlay, ls_client):
     mock_create_overlay.return_value = "fake_image"
     mock_image_as_bytes.return_value = b"fake_image_data"
+    ls_client.create_module = MagicMock(return_value={"id": 1})
+    ls_client.update_module = MagicMock(return_value={"id": 1})
     mock_put.return_value = mock_response(json_data="{}")
     mock_post.return_value = mock_response(json_data='{"data": {"id": 1}}')
     mock_get.return_value = mock_response(json_data='{"signed_request": "https://signed.url"}')


### PR DESCRIPTION
## What/Why?

Add check/create module step when inserting overlays.

## Testing

```python
import imageio
import numpy as np
import yaml
from proscia_ai_tools.concentriqlsclient import ConcentriqLSClient

with open('creds-main.yml', 'r') as file:
    creds = yaml.safe_load(file)

cls_client = ConcentriqLSClient(**creds)

overlay = imageio.v2.imread("~/Downloads/test_overlay_6538_main.png")
test_heatmap = overlay[:,:, 3]/255

cls_client.insert_heatmap_overlay(image_id=6538, heatmap=test_heatmap, result_name="test map", module_name="proscia-ai-tools test module")
```
![image](https://github.com/user-attachments/assets/1c725a35-dc17-4577-89a4-25f68a817d99)

```python
new_module = cls_client.create_module(module_name="my cool module")
updated_module = cls_client.update_module(module_id=new_module['id'], module_name="my cooler module", is_active= True)
new_module, updated_module
```

```
({'name': 'my cool module', 'isActive': False, 'id': 15},
 {'name': 'my cooler module', 'isActive': True, 'id': 15})
```

```python
cls_client.list_modules()
```

```
[{'id': 14, 'name': 'my cooler module', 'isActive': True},
 {'id': 13, 'name': 'proscia-ai-tools test module', 'isActive': True},
 {'id': 12, 'name': 'module create AR', 'isActive': True},
 {'id': 11, 'name': 'QC AI', 'isActive': True},
 ...
]
```


## Reviewers

@Proscia/ai-scientists 