### PR TITLE
embed images instead of the whole repo

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -314,7 +314,7 @@
         "filename": "notebooks/zero-shot-classification.ipynb",
         "hashed_secret": "13499a8245392c01a3b6bc876540d0421a393ebd",
         "is_verified": false,
-        "line_number": 699
+        "line_number": 712
       }
     ],
     "proscia_ai_tools/concentriq_embeddings_client/README.md": [
@@ -327,5 +327,5 @@
       }
     ]
   },
-  "generated_at": "2025-06-03T20:52:35Z"
+  "generated_at": "2025-06-03T21:06:54Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -314,7 +314,7 @@
         "filename": "notebooks/zero-shot-classification.ipynb",
         "hashed_secret": "13499a8245392c01a3b6bc876540d0421a393ebd",
         "is_verified": false,
-        "line_number": 698
+        "line_number": 699
       }
     ],
     "proscia_ai_tools/concentriq_embeddings_client/README.md": [
@@ -327,5 +327,5 @@
       }
     ]
   },
-  "generated_at": "2025-04-21T16:45:18Z"
+  "generated_at": "2025-06-03T20:52:35Z"
 }

--- a/notebooks/zero-shot-classification.ipynb
+++ b/notebooks/zero-shot-classification.ipynb
@@ -64,17 +64,18 @@
    "source": [
     "# Let's get some embeddings\n",
     "\n",
-    "Now let's embed the Camelyon17 repo (stored on Concentriq® LS with repo ID 2784) at 1 mpp resolution using `vinid/plip`, and print out the ticket ID. "
+    "Now let's embed an image from the Camelyon17 repo (stored on Concentriq® LS with repo ID 2784) at 1 mpp resolution using `vinid/plip`, and print out the ticket ID. "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "repository_ids = [2784]\n",
-    "ticket_id = ce_api_client.embed_repos(ids=repository_ids, model=\"vinid/plip\", mpp=1)\n",
+    "image_ids = [8469]\n",
+    "ticket_id = ce_api_client.embed_images(ids=image_ids, model=\"vinid/plip\", mpp=1)\n",
     "\n",
     "# Optionally load embeddings from a previously created ticket\n",
     "#ticket_id = \"6959742e-0e36-4493-91bb-74df61e6a27f\""
@@ -631,11 +632,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "image_id = 8485 # An id of a test image\n",
+    "image_id = image_ids[0] # An id of a test image\n",
     "slide_df = dataset_df[dataset_df['image_id']==image_id].copy()\n",
     "slide_df = get_similarity_df(slide_df, labels)\n",
     "mat = np.zeros((slide_df['grid_rows'].values[0], slide_df['grid_cols'].values[0]))\n",

--- a/notebooks/zero-shot-classification.ipynb
+++ b/notebooks/zero-shot-classification.ipynb
@@ -16,7 +16,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -40,7 +40,7 @@
     {
      "data": {
       "text/plain": [
-       "<utils.client.ClientWrapper at 0x7f906ef85110>"
+       "<proscia_ai_tools.client.ClientWrapper at 0x7f9dd843b580>"
       ]
      },
      "execution_count": 2,
@@ -69,12 +69,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
-    "repository_ids = [2784]\n",
-    "image_ids = [8469]\n",
+    "repository_ids = [2]\n",
+    "image_ids = [76]\n",
     "ticket_id = ce_api_client.embed_images(ids=image_ids, model=\"vinid/plip\", mpp=1)\n",
     "\n",
     "# Optionally load embeddings from a previously created ticket\n",
@@ -83,25 +83,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
-    "embeddings = ce_api_client.get_embeddings(ticket_id)"
+    "embeddings = ce_api_client.get_embeddings(ticket_id, polling_interval_seconds=30)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "100"
+       "1"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -112,7 +112,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -121,7 +121,7 @@
        "512"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -148,14 +148,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(100, 8)\n"
+      "(50, 8)\n"
      ]
     },
     {
@@ -192,51 +192,40 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>8410</td>\n",
-       "      <td>0.243094</td>\n",
-       "      <td>0.243094</td>\n",
-       "      <td>96651</td>\n",
-       "      <td>197226</td>\n",
-       "      <td>40</td>\n",
-       "      <td>patient_016_node_1.tif</td>\n",
-       "      <td>patient_016_node_1</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>8411</td>\n",
-       "      <td>0.243094</td>\n",
-       "      <td>0.243094</td>\n",
-       "      <td>96651</td>\n",
-       "      <td>197226</td>\n",
-       "      <td>40</td>\n",
-       "      <td>patient_073_node_1.tif</td>\n",
-       "      <td>patient_073_node_1</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>8412</td>\n",
+       "      <td>60</td>\n",
        "      <td>0.243094</td>\n",
        "      <td>0.243094</td>\n",
        "      <td>94968</td>\n",
        "      <td>210579</td>\n",
        "      <td>40</td>\n",
-       "      <td>patient_000_node_4.tif</td>\n",
-       "      <td>patient_000_node_4</td>\n",
+       "      <td>patient_009_node_1.tif</td>\n",
+       "      <td>patient_009_node_1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>61</td>\n",
+       "      <td>0.243094</td>\n",
+       "      <td>0.243094</td>\n",
+       "      <td>96651</td>\n",
+       "      <td>197226</td>\n",
+       "      <td>40</td>\n",
+       "      <td>patient_010_node_4.tif</td>\n",
+       "      <td>patient_010_node_4</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>62</td>\n",
+       "      <td>0.243094</td>\n",
+       "      <td>0.243094</td>\n",
+       "      <td>96651</td>\n",
+       "      <td>197226</td>\n",
+       "      <td>40</td>\n",
+       "      <td>patient_012_node_0.tif</td>\n",
+       "      <td>patient_012_node_0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>8413</td>\n",
-       "      <td>0.226316</td>\n",
-       "      <td>0.226321</td>\n",
-       "      <td>131072</td>\n",
-       "      <td>103936</td>\n",
-       "      <td>40</td>\n",
-       "      <td>patient_057_node_4.tif</td>\n",
-       "      <td>patient_057_node_4</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>8414</td>\n",
+       "      <td>63</td>\n",
        "      <td>0.243094</td>\n",
        "      <td>0.243094</td>\n",
        "      <td>94968</td>\n",
@@ -245,27 +234,38 @@
        "      <td>patient_020_node_4.tif</td>\n",
        "      <td>patient_020_node_4</td>\n",
        "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>64</td>\n",
+       "      <td>0.243094</td>\n",
+       "      <td>0.243094</td>\n",
+       "      <td>94968</td>\n",
+       "      <td>210579</td>\n",
+       "      <td>40</td>\n",
+       "      <td>patient_021_node_3.tif</td>\n",
+       "      <td>patient_021_node_3</td>\n",
+       "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
        "   image_id      mppx      mppy  imgWidth  imgHeight  objectivePower  \\\n",
-       "0      8410  0.243094  0.243094     96651     197226              40   \n",
-       "1      8411  0.243094  0.243094     96651     197226              40   \n",
-       "2      8412  0.243094  0.243094     94968     210579              40   \n",
-       "3      8413  0.226316  0.226321    131072     103936              40   \n",
-       "4      8414  0.243094  0.243094     94968     210579              40   \n",
+       "0        60  0.243094  0.243094     94968     210579              40   \n",
+       "1        61  0.243094  0.243094     96651     197226              40   \n",
+       "2        62  0.243094  0.243094     96651     197226              40   \n",
+       "3        63  0.243094  0.243094     94968     210579              40   \n",
+       "4        64  0.243094  0.243094     94968     210579              40   \n",
        "\n",
        "                slideName     image_base_name  \n",
-       "0  patient_016_node_1.tif  patient_016_node_1  \n",
-       "1  patient_073_node_1.tif  patient_073_node_1  \n",
-       "2  patient_000_node_4.tif  patient_000_node_4  \n",
-       "3  patient_057_node_4.tif  patient_057_node_4  \n",
-       "4  patient_020_node_4.tif  patient_020_node_4  "
+       "0  patient_009_node_1.tif  patient_009_node_1  \n",
+       "1  patient_010_node_4.tif  patient_010_node_4  \n",
+       "2  patient_012_node_0.tif  patient_012_node_0  \n",
+       "3  patient_020_node_4.tif  patient_020_node_4  \n",
+       "4  patient_021_node_3.tif  patient_021_node_3  "
       ]
      },
-     "execution_count": 7,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -296,24 +296,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "image_id: 8469\n",
-      "repository_id: 2784\n",
+      "image_id: 76\n",
+      "repository_id: None\n",
       "status: finished\n",
       "model: vinid/plip\n",
       "patch_size: 224\n",
-      "grid_rows: 215\n",
-      "grid_cols: 105\n",
-      "pad_height: 216\n",
-      "pad_width: 25\n",
+      "grid_rows: 229\n",
+      "grid_cols: 104\n",
+      "pad_height: 106\n",
+      "pad_width: 210\n",
       "mpp: 1.0\n",
-      "local_embedding_path: ./data/6959742e-0e36-4493-91bb-74df61e6a27f_8469.safetensors\n"
+      "local_embedding_path: ./data/443fb8d8-759d-4822-bdbc-213943ec969c_76.safetensors\n"
      ]
     }
    ],
@@ -333,16 +333,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "(1967019, 8)"
+       "(23816, 8)"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -353,9 +353,12 @@
     "for i, row in concentriq_metadata.iterrows():\n",
     "    image_id = row[\"image_id\"]\n",
     "    image_base_name = row[\"image_base_name\"]\n",
-    "    emb = [e for e in embeddings['images'] if e[\"image_id\"] == image_id][0]\n",
+    "    emb = [e for e in embeddings['images'] if e[\"image_id\"] == image_id]\n",
+    "    if len(emb) == 0:\n",
+    "        continue\n",
+    "    emb = emb[0]\n",
     "    tile_res_mask_path = os.path.join(datapath, f\"{image_base_name}_mask.png\")\n",
-    "    tile_res_mask = imageio.v2.imread(tile_res_mask_path)    \n",
+    "    tile_res_mask = imageio.v2.imread(tile_res_mask_path)\n",
     "    # For each image, create one row per tile in the mask\n",
     "    for i in range(emb[\"grid_rows\"]):\n",
     "        for j in range(emb[\"grid_cols\"]):\n",
@@ -377,7 +380,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -414,58 +417,58 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>8410</td>\n",
-       "      <td>patient_016_node_1</td>\n",
+       "      <td>76</td>\n",
+       "      <td>patient_017_node_2</td>\n",
        "      <td>0</td>\n",
        "      <td>0</td>\n",
        "      <td>0</td>\n",
-       "      <td>[tensor(0.1216, dtype=torch.bfloat16), tensor(...</td>\n",
-       "      <td>215</td>\n",
-       "      <td>105</td>\n",
+       "      <td>[tensor(0.1216), tensor(-0.1216), tensor(-0.49...</td>\n",
+       "      <td>229</td>\n",
+       "      <td>104</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>8410</td>\n",
-       "      <td>patient_016_node_1</td>\n",
+       "      <td>76</td>\n",
+       "      <td>patient_017_node_2</td>\n",
        "      <td>0</td>\n",
        "      <td>0</td>\n",
        "      <td>1</td>\n",
-       "      <td>[tensor(0.1216, dtype=torch.bfloat16), tensor(...</td>\n",
-       "      <td>215</td>\n",
-       "      <td>105</td>\n",
+       "      <td>[tensor(0.1216), tensor(-0.1216), tensor(-0.49...</td>\n",
+       "      <td>229</td>\n",
+       "      <td>104</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>8410</td>\n",
-       "      <td>patient_016_node_1</td>\n",
+       "      <td>76</td>\n",
+       "      <td>patient_017_node_2</td>\n",
        "      <td>0</td>\n",
        "      <td>0</td>\n",
        "      <td>2</td>\n",
-       "      <td>[tensor(0.1216, dtype=torch.bfloat16), tensor(...</td>\n",
-       "      <td>215</td>\n",
-       "      <td>105</td>\n",
+       "      <td>[tensor(0.1216), tensor(-0.1216), tensor(-0.49...</td>\n",
+       "      <td>229</td>\n",
+       "      <td>104</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>8410</td>\n",
-       "      <td>patient_016_node_1</td>\n",
+       "      <td>76</td>\n",
+       "      <td>patient_017_node_2</td>\n",
        "      <td>0</td>\n",
        "      <td>0</td>\n",
        "      <td>3</td>\n",
-       "      <td>[tensor(0.1216, dtype=torch.bfloat16), tensor(...</td>\n",
-       "      <td>215</td>\n",
-       "      <td>105</td>\n",
+       "      <td>[tensor(0.1216), tensor(-0.1216), tensor(-0.49...</td>\n",
+       "      <td>229</td>\n",
+       "      <td>104</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td>8410</td>\n",
-       "      <td>patient_016_node_1</td>\n",
+       "      <td>76</td>\n",
+       "      <td>patient_017_node_2</td>\n",
        "      <td>0</td>\n",
        "      <td>0</td>\n",
        "      <td>4</td>\n",
-       "      <td>[tensor(0.1216, dtype=torch.bfloat16), tensor(...</td>\n",
-       "      <td>215</td>\n",
-       "      <td>105</td>\n",
+       "      <td>[tensor(0.1216), tensor(-0.1216), tensor(-0.49...</td>\n",
+       "      <td>229</td>\n",
+       "      <td>104</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -473,21 +476,21 @@
       ],
       "text/plain": [
        "   image_id     image_base_name  label  row  col  \\\n",
-       "0      8410  patient_016_node_1      0    0    0   \n",
-       "1      8410  patient_016_node_1      0    0    1   \n",
-       "2      8410  patient_016_node_1      0    0    2   \n",
-       "3      8410  patient_016_node_1      0    0    3   \n",
-       "4      8410  patient_016_node_1      0    0    4   \n",
+       "0        76  patient_017_node_2      0    0    0   \n",
+       "1        76  patient_017_node_2      0    0    1   \n",
+       "2        76  patient_017_node_2      0    0    2   \n",
+       "3        76  patient_017_node_2      0    0    3   \n",
+       "4        76  patient_017_node_2      0    0    4   \n",
        "\n",
        "                                           embedding  grid_rows  grid_cols  \n",
-       "0  [tensor(0.1216, dtype=torch.bfloat16), tensor(...        215        105  \n",
-       "1  [tensor(0.1216, dtype=torch.bfloat16), tensor(...        215        105  \n",
-       "2  [tensor(0.1216, dtype=torch.bfloat16), tensor(...        215        105  \n",
-       "3  [tensor(0.1216, dtype=torch.bfloat16), tensor(...        215        105  \n",
-       "4  [tensor(0.1216, dtype=torch.bfloat16), tensor(...        215        105  "
+       "0  [tensor(0.1216), tensor(-0.1216), tensor(-0.49...        229        104  \n",
+       "1  [tensor(0.1216), tensor(-0.1216), tensor(-0.49...        229        104  \n",
+       "2  [tensor(0.1216), tensor(-0.1216), tensor(-0.49...        229        104  \n",
+       "3  [tensor(0.1216), tensor(-0.1216), tensor(-0.49...        229        104  \n",
+       "4  [tensor(0.1216), tensor(-0.1216), tensor(-0.49...        229        104  "
       ]
      },
-     "execution_count": 10,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -498,20 +501,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
        "label\n",
-       "0    1550701\n",
-       "1     410897\n",
-       "2       5421\n",
+       "0    20600\n",
+       "1     2985\n",
+       "2      231\n",
        "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -529,16 +532,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "(416318, 8)"
+       "(3216, 8)"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -560,9 +563,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 18,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Using a slow image processor as `use_fast` is unset and a slow processor was saved with this model. `use_fast=True` will be the default behavior in v4.52, even if the model was saved with a slow processor. This will result in minor differences in outputs. You'll still be able to use a slow processor with `use_fast=False`.\n"
+     ]
+    }
+   ],
    "source": [
     "from transformers import AutoProcessor, CLIPModel\n",
     "\n",
@@ -594,7 +605,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -632,7 +643,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -665,7 +676,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -683,14 +694,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [],
    "source": [
-    "cls.insert_annotations_from_mask(image_id=image_id, \n",
-    "                                mask=tile_resolution_mask, \n",
-    "                                mask_mpp=1, \n",
-    "                                annotation_name=\"Tumor Ground Truth\")"
+    "annotations = cls.insert_annotations_from_mask(\n",
+    "    image_id=image_id, \n",
+    "    mask=tile_resolution_mask,\n",
+    "    mask_mpp=1, \n",
+    "    annotation_name=\"Tumor Ground Truth\"\n",
+    ")"
    ]
   },
   {
@@ -717,7 +730,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "pait",
+   "display_name": ".venv",
    "language": "python",
    "name": "python3"
   },
@@ -731,7 +744,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## What/Why?

Avoid unnecessary compute. `s/embed_repositories/embed_images` in zero-shot notebook example.

## Testing

ran `notebooks/zero-shot-classification.ipynb` :+1: 

## Reviewers

@Proscia/ai-scientists 