### PR TITLE
feat(AT-3408): Support API key and JWT token auth for Embeddings 2.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,75 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Python SDK for interacting with Proscia's Concentriq platform for digital pathology AI development. The library provides:
+
+- **Concentriq Embeddings API**: Extract foundation model embeddings from whole slide images (WSIs)
+- **Concentriq LS API**: Interact with the Concentriq LS platform for image/repository management, overlays, and annotations
+
+## Build and Test Commands
+
+```bash
+# Install dependencies
+poetry install
+
+# Run all tests
+pytest
+
+# Run a single test file
+pytest tests/test_client.py
+
+# Run a specific test
+pytest tests/test_client.py::test_submit_job
+
+# Run with coverage
+pytest --cov=proscia_ai_tools
+
+# Type checking
+mypy proscia_ai_tools
+
+# Linting (auto-fixes enabled)
+ruff check proscia_ai_tools
+ruff format proscia_ai_tools
+```
+
+## Architecture
+
+### Client Layer (`proscia_ai_tools/`)
+
+- **`client.py`** - `ClientWrapper`: High-level wrapper for embeddings workflows. Handles authentication token refresh, job submission, polling, result caching, and embedding/thumbnail download/loading.
+
+- **`concentriqlsclient.py`** - `ConcentriqLSClient`: Client for the Concentriq LS REST API. Manages images, repositories, overlays (heatmaps), annotations, and annotation classes. Uses paginated queries for large result sets.
+
+- **`concentriq_embeddings_client/client.py`** - `ConcentriqEmbeddingsClient`: Low-level client for the embeddings service API endpoints (submit job, get status, fetch results, ROI selection).
+
+### Supporting Modules
+
+- **`annotations.py`**: Data models for Concentriq annotations (`ConcentriqAnnotation`, `AnnotationShape`, `AnnotationBounds`) and conversion utilities between pixel/viewport coordinates, mask-to-contour conversion, and Aperio XML export.
+
+- **`utils.py`**: Image processing utilities - overlay creation, mask overlay, thumbnail tiling, embedding parsing, and evaluation metrics (IoU, Dice, confusion matrix).
+
+### Authentication Pattern
+
+Both clients use bearer token auth obtained via basic auth to `/api/v3/auth/token`. The `catch_auth_exceptions` decorator automatically refreshes tokens on HTTPError.
+
+### Embeddings Workflow
+
+1. Submit job with image/repository IDs, model tag, and MPP (microns per pixel)
+2. Poll job status until complete
+3. Fetch results (paginated) containing presigned S3 URLs
+4. Download `.safetensors` files to local cache
+5. Load tensors with `safe_open()` to PyTorch device
+
+### Supported Foundation Models
+
+DinoV2, PLIP, ConvNext, CTransPath, H-optimus-0, Virchow (see README for model tags and embedding dimensions).
+
+## Code Style
+
+- Line length: 120 characters
+- Uses ruff for linting with flake8-compatible rules
+- Type hints encouraged (mypy configured)
+- Tests use pytest with mocking via `unittest.mock`

--- a/proscia_ai_tools/client.py
+++ b/proscia_ai_tools/client.py
@@ -25,22 +25,67 @@ class ClientWrapper:
     """
     A wrapper around the Concentriq Embeddings client.
 
+    Provide exactly one of the following auth methods:
+      - ``email`` + ``password``: Basic auth credentials (exchanged for a JWT).
+      - ``token``: A pre-obtained JWT bearer token.
+      - ``api_key``: A Concentriq API key.
+
     Parameters
     ----------
-    url (str): The URL of the Concentriq Embeddings endpoint.
-    email (str): The email address to use for authentication.
-    password (str): The password to use for authentication.
-    cache_dir (str, optional): The directory to use for caching results. Defaults to `./data`.
+    url : str
+        The URL of the Concentriq Embeddings endpoint.
+    email : str, optional
+        The email address to use for basic authentication.
+    password : str, optional
+        The password to use for basic authentication.
+    cache_dir : str, optional
+        The directory to use for caching results. Defaults to ``./data``.
+    device : int, optional
+        The PyTorch device index. Defaults to 0.
+    api_version : str, optional
+        The embeddings API version. Defaults to ``v1``.
+    token : str, optional
+        A pre-obtained JWT bearer token.
+    api_key : str, optional
+        A Concentriq API key.
     """
 
-    def __init__(self, url: str, email: str, password: str, cache_dir="./data", device: int = 0, api_version="v1"):
+    def __init__(
+        self,
+        url: str,
+        email: str | None = None,
+        password: str | None = None,
+        cache_dir="./data",
+        device: int = 0,
+        api_version="v1",
+        *,
+        token: str | None = None,
+        api_key: str | None = None,
+    ):
         self.cache_dir = cache_dir
         self.device = device
         self.base_url = url
         self.email = email
         self.password = password
         self.api_version = api_version
-        self.refresh_client_token()
+        self._token = token
+        self._api_key = api_key
+
+        has_basic = email is not None and password is not None
+        has_token = token is not None
+        has_api_key = api_key is not None
+        provided = sum([has_basic, has_token, has_api_key])
+        if provided != 1:
+            raise ValueError("Provide exactly one auth method: email+password, token, or api_key.")  # noqa: TRY003
+
+        if has_basic:
+            self._auth_method = "basic"
+        elif has_token:
+            self._auth_method = "jwt"
+        else:
+            self._auth_method = "api_key"
+
+        self._init_client()
 
     def catch_auth_exceptions(func):
         @wraps(func)
@@ -48,14 +93,32 @@ class ClientWrapper:
             try:
                 return func(self, *args, **kwargs)
             except HTTPError:
-                self.refresh_client_token()
-                return func(self, *args, **kwargs)
+                if self._auth_method == "basic":
+                    self._init_client()
+                    return func(self, *args, **kwargs)
+                raise
 
         return wrapper
 
+    def _init_client(self):
+        if self._auth_method == "basic":
+            self._get_token()
+            self.client = ConcentriqEmbeddingsClient(
+                base_url=self.base_url, token=self.token, api_version=self.api_version
+            )
+        elif self._auth_method == "jwt":
+            self.token = self._token
+            self.client = ConcentriqEmbeddingsClient(
+                base_url=self.base_url, token=self._token, api_version=self.api_version
+            )
+        else:
+            self.token = None
+            self.client = ConcentriqEmbeddingsClient(
+                base_url=self.base_url, api_key=self._api_key, api_version=self.api_version
+            )
+
     def refresh_client_token(self):
-        self._get_token()
-        self.client = ConcentriqEmbeddingsClient(base_url=self.base_url, token=self.token, api_version=self.api_version)
+        self._init_client()
 
     def _get_token(self) -> None:
         url = f"{self.base_url}/api/v3/auth/token"

--- a/proscia_ai_tools/concentriq_embeddings_client/client.py
+++ b/proscia_ai_tools/concentriq_embeddings_client/client.py
@@ -1,3 +1,4 @@
+import base64
 import time
 
 import requests
@@ -11,6 +12,8 @@ from proscia_ai_tools.concentriq_embeddings_client.models import (
     SubmissionResponse,
     ThumbnailsJobOutput,
 )
+
+API_KEY_HEADER_NAME = "concentriq-api-key"  # pragma: allowlist secret
 
 
 class DetailedHTTPError(requests.exceptions.HTTPError):
@@ -30,30 +33,52 @@ class DetailedHTTPError(requests.exceptions.HTTPError):
 
 
 class ConcentriqEmbeddingsClient:
-    def __init__(self, base_url: str, token: str, api_version: str = "v1"):
+    def __init__(
+        self,
+        base_url: str,
+        token: str | None = None,
+        api_version: str = "v1",
+        *,
+        email: str | None = None,
+        password: str | None = None,
+        api_key: str | None = None,
+    ):
         """Client for the Concentriq Embeddings service.
 
-        Args:
-            base_url (str): The base URL of the embeddings service
-            token (str): The API token. Your token can be obtained via basic auth
-                using the `<base_url>/api/v3/auth/token endpoint.
-            api_version (str): The embeddings API version
+        Provide exactly one of the following auth methods:
+          - ``token``: A JWT bearer token (from ``/api/v3/auth/token``).
+          - ``email`` + ``password``: Basic auth credentials.
+          - ``api_key``: A Concentriq API key.
 
-        Example:
-            client = ConcentriqEmbeddingsClient(
-                base_url="https://concentriq-ls.com",
-                token="your_token_here",
-                api_version="v1"
-            )
+        Args:
+            base_url: The base URL of the embeddings service.
+            token: JWT bearer token.
+            api_version: The embeddings API version.
+            email: Email for basic auth.
+            password: Password for basic auth.
+            api_key: Concentriq API key.
         """
         self.base_url = base_url
-        self.token = token
         self.api_version = api_version
         self.session = requests.Session()
         retries = Retry(total=5, backoff_factor=1, status_forcelist=[502, 503, 504])
         self.session.mount("http://", HTTPAdapter(max_retries=retries))
         self.session.mount("https://", HTTPAdapter(max_retries=retries))
-        self.session.headers.update({"token": self.token})
+
+        has_basic = email is not None and password is not None
+        has_token = token is not None
+        has_api_key = api_key is not None
+        provided = sum([has_basic, has_token, has_api_key])
+        if provided != 1:
+            raise ValueError("Provide exactly one auth method: token, email+password, or api_key.")  # noqa: TRY003
+
+        if has_token:
+            self.session.headers.update({"Authorization": f"Bearer {token}"})
+        elif has_basic:
+            encoded = base64.b64encode(f"{email}:{password}".encode()).decode()
+            self.session.headers.update({"Authorization": f"Basic {encoded}"})
+        elif has_api_key:
+            self.session.headers.update({API_KEY_HEADER_NAME: api_key})
 
     def submit_job(self, data: dict, thumbnails: bool = False) -> SubmissionResponse:
         """Method to submit a job to the embeddings service.

--- a/proscia_ai_tools/concentriqlsclient.py
+++ b/proscia_ai_tools/concentriqlsclient.py
@@ -14,6 +14,8 @@ from urllib3.util.retry import Retry
 from proscia_ai_tools import utils
 from proscia_ai_tools.annotations import ConcentriqAnnotation, create_contour_annotation, mask2contours
 
+API_KEY_HEADER_NAME = "concentriq-api-key"  # pragma: allowlist secret
+
 
 class GetException(Exception):
     """Exception raised when get request fails."""
@@ -26,8 +28,22 @@ class GetException(Exception):
 class ConcentriqLSClient:
     DEFAULT_PAGINATION_ITEM_COUNT = 500
 
-    def __init__(self, url: str, email: str, password: str, pagination_info=None):
+    def __init__(
+        self,
+        url: str,
+        email: str | None = None,
+        password: str | None = None,
+        pagination_info=None,
+        *,
+        token: str | None = None,
+        api_key: str | None = None,
+    ):
         """Client for the Concentriq LS api.
+
+        Provide exactly one of the following auth methods:
+          - ``email`` + ``password``: Basic auth credentials (exchanged for a JWT).
+          - ``token``: A pre-obtained JWT bearer token.
+          - ``api_key``: A Concentriq API key.
 
         Parameters:
         -----------
@@ -50,6 +66,8 @@ class ConcentriqLSClient:
                 Note: When paginated queries are involved user has to be aware of
                 affect of sorting configuration default is robust to an extent to
                 prevent any duplicates
+        token: "str" pre-obtained JWT bearer token
+        api_key: "str" Concentriq API key  # pragma: allowlist secret
         """
         self.logger = logging.getLogger(self.__class__.__name__)
         if pagination_info is None:
@@ -57,12 +75,28 @@ class ConcentriqLSClient:
         self.endpoint = f"{url}/api"
         self.username = email
         self.password = password
+        self._token = token
+        self._api_key = api_key
+
+        has_basic = email is not None and password is not None
+        has_token = token is not None
+        has_api_key = api_key is not None
+        provided = sum([has_basic, has_token, has_api_key])
+        if provided != 1:
+            raise ValueError("Provide exactly one auth method: email+password, token, or api_key.")  # noqa: TRY003
+
+        if has_basic:
+            self._auth_method = "basic"
+        elif has_token:
+            self._auth_method = "jwt"
+        else:
+            self._auth_method = "api_key"
 
         retries = Retry(total=5, backoff_factor=1, status_forcelist=[502, 503, 504])
         self.session = requests.Session()
         self.session.mount("http://", HTTPAdapter(max_retries=retries))
         self.session.mount("https://", HTTPAdapter(max_retries=retries))
-        self.refresh_client_token()
+        self._apply_auth()
 
         pagination_info["page"] = 1
         pagination_info["descending"] = pagination_info.get("descending", False)
@@ -78,8 +112,10 @@ class ConcentriqLSClient:
             try:
                 return func(self, *args, **kwargs)
             except HTTPError:
-                self.refresh_client_token()
-                return func(self, *args, **kwargs)
+                if self._auth_method == "basic":
+                    self.refresh_client_token()
+                    return func(self, *args, **kwargs)
+                raise
 
         return wrapper
 
@@ -91,9 +127,19 @@ class ConcentriqLSClient:
         )
         self.token = response.json().get("token", None)
 
+    def _apply_auth(self):
+        if self._auth_method == "basic":
+            self._get_token()
+            self.session.headers.update({"Authorization": f"Bearer {self.token}"})
+        elif self._auth_method == "jwt":
+            self.token = self._token
+            self.session.headers.update({"Authorization": f"Bearer {self._token}"})
+        else:
+            self.token = None
+            self.session.headers.update({API_KEY_HEADER_NAME: self._api_key})
+
     def refresh_client_token(self):
-        self._get_token()
-        self.session.headers.update({"Authorization": f"Bearer {self.token}"})
+        self._apply_auth()
 
     @catch_auth_exceptions
     def create_overlay(self, image_id: int, overlay_name: str, module_name: str = "proscia-ai-tools") -> dict:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "proscia-ai-tools"
-version = "0.0.1"
+version = "0.1.0"
 description = "This is a software contains python code to interact with the Proscia Foundation Embedder API."
 authors = ["Proscia AI Team <ai_team@proscia.com>"]
 packages = [

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,3 +1,4 @@
+import base64
 import os
 from unittest.mock import patch
 
@@ -5,7 +6,7 @@ import pytest
 from requests.models import Response
 
 from proscia_ai_tools.client import ClientWrapper
-from proscia_ai_tools.concentriq_embeddings_client.client import ConcentriqEmbeddingsClient
+from proscia_ai_tools.concentriq_embeddings_client.client import API_KEY_HEADER_NAME, ConcentriqEmbeddingsClient
 from proscia_ai_tools.concentriq_embeddings_client.models import (
     EstimationResponse,
     JobOutput,
@@ -250,3 +251,63 @@ def test_poll_for_completion_and_fetch_results(mock_fetch_results, mock_get_job_
         thumbnails = client_wrapper.get_thumbnails("1234")
         assert len(thumbnails["thumbnails"]) == 1
         assert thumbnails["thumbnails"][0]["image_id"] == 1
+
+
+# --- ConcentriqEmbeddingsClient auth tests ---
+
+
+class TestEmbeddingsClientAuth:
+    def test_token_auth_sets_bearer_header(self):
+        client = ConcentriqEmbeddingsClient(base_url=BASE_URL, token="my-jwt")  # noqa: S106
+        assert client.session.headers["Authorization"] == "Bearer my-jwt"
+        assert API_KEY_HEADER_NAME not in client.session.headers
+
+    def test_basic_auth_sets_authorization_header(self):
+        client = ConcentriqEmbeddingsClient(base_url=BASE_URL, email="user@example.com", password="secret")  # noqa: S106
+        expected = "Basic " + base64.b64encode(b"user@example.com:secret").decode()
+        assert client.session.headers["Authorization"] == expected
+
+    def test_api_key_auth_sets_api_key_header(self):
+        client = ConcentriqEmbeddingsClient(base_url=BASE_URL, api_key="my-api-key")  # pragma: allowlist secret
+        assert client.session.headers[API_KEY_HEADER_NAME] == "my-api-key"  # pragma: allowlist secret
+        assert "Authorization" not in client.session.headers
+
+    def test_no_auth_raises(self):
+        with pytest.raises(ValueError, match="Provide exactly one auth method"):
+            ConcentriqEmbeddingsClient(base_url=BASE_URL)
+
+    def test_multiple_auth_raises(self):
+        with pytest.raises(ValueError, match="Provide exactly one auth method"):
+            ConcentriqEmbeddingsClient(base_url=BASE_URL, token="tok", api_key="key")  # noqa: S106  # pragma: allowlist secret
+
+
+# --- ClientWrapper auth tests ---
+
+
+class TestClientWrapperAuth:
+    @patch("requests.request")
+    def test_basic_auth(self, mock_request):
+        mock_request.return_value.json.return_value = {"token": "jwt-from-exchange"}
+        wrapper = ClientWrapper(url=BASE_URL, email="user@example.com", password="secret")  # noqa: S106
+        assert wrapper._auth_method == "basic"
+        assert wrapper.token == "jwt-from-exchange"  # noqa: S105
+        assert wrapper.client.session.headers["Authorization"] == "Bearer jwt-from-exchange"
+
+    def test_token_auth(self):
+        wrapper = ClientWrapper(url=BASE_URL, token="pre-obtained-jwt")  # noqa: S106
+        assert wrapper._auth_method == "jwt"
+        assert wrapper.token == "pre-obtained-jwt"  # noqa: S105
+        assert wrapper.client.session.headers["Authorization"] == "Bearer pre-obtained-jwt"
+
+    def test_api_key_auth(self):
+        wrapper = ClientWrapper(url=BASE_URL, api_key="my-api-key")  # pragma: allowlist secret
+        assert wrapper._auth_method == "api_key"
+        assert wrapper.client.session.headers[API_KEY_HEADER_NAME] == "my-api-key"  # pragma: allowlist secret
+
+    def test_no_auth_raises(self):
+        with pytest.raises(ValueError, match="Provide exactly one auth method"):
+            ClientWrapper(url=BASE_URL)
+
+    def test_multiple_auth_raises(self):
+        with pytest.raises(ValueError, match="Provide exactly one auth method"):
+            ClientWrapper(url=BASE_URL, email="u@e.com", password="p", api_key="key")  # noqa: S106  # pragma: allowlist secret

--- a/tests/test_concentriqlsclient.py
+++ b/tests/test_concentriqlsclient.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import pytest
 
-from proscia_ai_tools.concentriqlsclient import ConcentriqLSClient
+from proscia_ai_tools.concentriqlsclient import API_KEY_HEADER_NAME, ConcentriqLSClient
 
 BASE_URL = "https://concentriq-ls.com"
 EMAIL = "test@example.com"
@@ -146,3 +146,36 @@ def test_get_annotations(mock_get, ls_client):
     annotations = ls_client.get_annotations(image_ids=[1])
     assert annotations["annotations"][0]["id"] == 1
     assert annotations["annotations"][0]["name"] == "annotation"
+
+
+# --- ConcentriqLSClient auth tests ---
+
+
+class TestLSClientAuth:
+    @patch("requests.request")
+    def test_basic_auth(self, mock_request):
+        mock_request.return_value = mock_response(json_data='{"token": "jwt-from-exchange"}')
+        client = ConcentriqLSClient(url=BASE_URL, email=EMAIL, password=PASSWORD)
+        assert client._auth_method == "basic"
+        assert client.token == "jwt-from-exchange"  # noqa: S105
+        assert client.session.headers["Authorization"] == "Bearer jwt-from-exchange"
+
+    def test_token_auth(self):
+        client = ConcentriqLSClient(url=BASE_URL, token="pre-obtained-jwt")  # noqa: S106
+        assert client._auth_method == "jwt"
+        assert client.token == "pre-obtained-jwt"  # noqa: S105
+        assert client.session.headers["Authorization"] == "Bearer pre-obtained-jwt"
+
+    def test_api_key_auth(self):
+        client = ConcentriqLSClient(url=BASE_URL, api_key="my-api-key")  # pragma: allowlist secret
+        assert client._auth_method == "api_key"
+        assert client.session.headers[API_KEY_HEADER_NAME] == "my-api-key"  # pragma: allowlist secret
+        assert "Authorization" not in client.session.headers
+
+    def test_no_auth_raises(self):
+        with pytest.raises(ValueError, match="Provide exactly one auth method"):
+            ConcentriqLSClient(url=BASE_URL)
+
+    def test_multiple_auth_raises(self):
+        with pytest.raises(ValueError, match="Provide exactly one auth method"):
+            ConcentriqLSClient(url=BASE_URL, email=EMAIL, password=PASSWORD, api_key="key")  # pragma: allowlist secret


### PR DESCRIPTION
## Summary
- Add `token` (pre-obtained JWT) and `api_key` auth methods alongside existing `email`+`password` basic auth across all three clients: `ClientWrapper`, `ConcentriqEmbeddingsClient`, and `ConcentriqLSClient`
- Each client validates that exactly one auth method is provided and sets the appropriate HTTP headers (`Authorization: Bearer`, `Authorization: Basic`, or `concentriq-api-key`)
- Token auto-refresh on `HTTPError` only applies to basic auth sessions; JWT and API key sessions re-raise

## Test plan
- [x] All 58 existing tests pass
- [x] New auth tests cover all three auth methods per client
- [x] Validation tests confirm errors on missing or multiple auth methods
- [ ] Manual integration test with a real API key against a staging environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)