### PR TITLE
ci(TEC-3635): bump GitHub Actions to Node 24 compatible versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,11 +21,11 @@ jobs:
 
     steps:
       - name: Set up Python 3.11
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Run pre-commit
         run: |
@@ -40,18 +40,18 @@ jobs:
 
     steps:
       - name: Set up Python 3.11
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Install Poetry
         run: |
           curl -sSL https://install.python-poetry.org | python3 -
           echo "${HOME}/.local/bin:$GITHUB_PATH" >> $GITHUB_PATH
 
       - name: Cache poetry virtualenv
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         id: cache
         with:
           path: ~/.cache/pypoetry/virtualenvs


### PR DESCRIPTION
Jira: TEC-3635

Bumps GitHub Actions references to Node 24 compatible versions (in place, no change to which actions are used).

| Action | Old | New |
|---|---|---|
| actions/setup-python | v4 | v6 |
| actions/checkout | v3 | v5 |
| actions/cache | v3 | v5 |

Migration to the central composite actions in `proscia-techops/github-actions-workflows` is deferred until PR #35 there merges (adopting them today introduces a Node 20 deprecation annotation via `docker/metadata-action@902fa8ec` v5.7.0).

No refs left unresolved.